### PR TITLE
Restore Finanzierung von Erweiterungen

### DIFF
--- a/2024/camp-2024.md
+++ b/2024/camp-2024.md
@@ -159,6 +159,14 @@ Andere CMS, die in der Contao Community je nach Anforderung auch verwendet werde
 ### Wie geht: Trakked [Bjarke ]
 
 ### Finanzierung von Erweiterungen [Andreas Schemp]
+- es wurden verschiedene Wege für Refinanzierung erörtert
+- "early-adopter-programm" wie bei MetaModels, Contao-Bootstrap, Include-Erweiterung - also mit Programmierung in 
+  Vorleistung gehen und einen finanziellen Beitrag für sofortige Nutzung bekommen; Ingolf hat im Vorfeld zu "EAP" eine
+  Umfrage bei Agenturen gemacht und das sit für viele eine gute Option für die Projektplanung
+- klassisches Fundraising like Kickstarter - wenig Bereitschaft im DACH-Bereich für diese Variante der Finanzierung
+- Klassische Bezahlvariante - ggf. vorhandene Lizenzbedingungen beachten
+- Variante mit freier Verfügbarkeit und zu bezahlenden Plugins
+- schwierig ist die Umstellung von bisherigen kostenlosen Varianten zu einer Bezahlvariante
 
 ### Tools für Coding [Stefan Lindecke]
 


### PR DESCRIPTION
Github hat bei meinem PR irgendwie noch ein paar Änderungen hinzugefügt. Die Session Finanzierung von Erweiterungen wurde verschluckt. Der PR stellt die Notizen wieder her. 